### PR TITLE
Vectorized implementation of plot_edges

### DIFF
--- a/meshkernel/utils.py
+++ b/meshkernel/utils.py
@@ -1,3 +1,9 @@
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib import colors as mcolors
+from matplotlib.collections import LineCollection
+
+
 def plot_edges(node_x, node_y, edge_nodes, ax, *args, **kwargs):
     """Plots the edges at a given axes.
     `args` and `kwargs` will be used as parameters of the `plot` method.
@@ -9,17 +15,20 @@ def plot_edges(node_x, node_y, edge_nodes, ax, *args, **kwargs):
         edge_nodes (ndarray, optional): A 1D integer array describing the nodes composing each mesh 2d edge.
         ax (matplotlib.axes.Axes): The axes where to plot the edges
     """
-    for edge_index in range(0, edge_nodes.size, 2):
-        first_edge_node_index = edge_nodes[edge_index]
-        second_edge_node_index = edge_nodes[edge_index + 1]
+    n_edge = int(edge_nodes.size / 2)
+    edge_coords = np.empty((n_edge, 2, 2), dtype=np.float64)
+    node_0 = edge_nodes[0::2]
+    node_1 = edge_nodes[1::2]
+    edge_coords[:, 0, 0] = node_x[node_0]
+    edge_coords[:, 0, 1] = node_y[node_0]
+    edge_coords[:, 1, 0] = node_x[node_1]
+    edge_coords[:, 1, 1] = node_y[node_1]
 
-        edge_x = [
-            node_x[first_edge_node_index],
-            node_x[second_edge_node_index],
+    if "colors" not in kwargs:
+        kwargs["colors"] = [
+            mcolors.to_rgba(c)
+            for c in plt.rcParams["axes.prop_cycle"].by_key()["color"]
         ]
-        edge_y = [
-            node_y[first_edge_node_index],
-            node_y[second_edge_node_index],
-        ]
-
-        ax.plot(edge_x, edge_y, *args, **kwargs)
+    line_segments = LineCollection(edge_coords, *args, **kwargs)
+    ax.add_collection(line_segments)
+    ax.autoscale(enable=True)

--- a/meshkernel/utils.py
+++ b/meshkernel/utils.py
@@ -23,12 +23,6 @@ def plot_edges(node_x, node_y, edge_nodes, ax, *args, **kwargs):
     edge_coords[:, 0, 1] = node_y[node_0]
     edge_coords[:, 1, 0] = node_x[node_1]
     edge_coords[:, 1, 1] = node_y[node_1]
-
-    if "colors" not in kwargs:
-        kwargs["colors"] = [
-            mcolors.to_rgba(c)
-            for c in plt.rcParams["axes.prop_cycle"].by_key()["color"]
-        ]
     line_segments = LineCollection(edge_coords, *args, **kwargs)
     ax.add_collection(line_segments)
     ax.autoscale(enable=True)


### PR DESCRIPTION
This is a vectorized implementation of plot_edges via `matplotlib`'s `LineCollection`, which is around an order of magnitude faster: ~ factor 8 for 392 edges, factor 15 for a larger example of 988 edges. It probably makes even more of a difference for larger numbers of edges, but 988 edges already takes 0.6 seconds with the unvectorized implementation.

Tested via:
```python
fig, ax = plt.subplots()
%timeit ax.clear(); meshkernel.utils.plot_edges(node_x, node_y, edge_nodes, ax)
```

Some details to note: 

* for some reason, the ax limits are not updated for adding a `LineCollection`.
Calling `ax.autoscale` updates them appropriately.
* by default, a LineCollection colors the edges a single color while the current `plot_edges` cycles through colors as they're added one by one. So if colors are not specified in `kwargs`, I add the colors of the current color cycle. This does mean that if someone were to give colors as an unnamed argument via `*args`, they'd get ignored. It seems likely matplotlib also does this on occasions, but I haven't tested it yet.

