### PR TITLE
fix: correct asserts in test_contacts_compute_single

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,6 @@ try:
             python, abi = "py3", "none"
             return python, abi, plat
 
-
 except ImportError:
     bdist_wheel = None
 
@@ -109,7 +108,7 @@ setup(
         "tests": ["pytest", "pytest-cov", "nbval", "matplotlib"],
         "lint": [
             "flake8",
-            "black==21.4b1",
+            "black",
             "isort",
         ],
         "docs": ["sphinx", "sphinx_book_theme", "myst_nb"],

--- a/tests/test_mesh1d_basics.py
+++ b/tests/test_mesh1d_basics.py
@@ -83,16 +83,20 @@ def test_contacts_compute_single():
     contacts = mk.contacts_get()
     contacts = sort_contacts_by_mesh2d_indices(contacts)
 
-    assert contacts.mesh1d_indices.size == 3
-    assert contacts.mesh2d_indices.size == 3
+    assert contacts.mesh1d_indices.size == 5
+    assert contacts.mesh2d_indices.size == 5
 
-    assert contacts.mesh1d_indices[0] == 1
-    assert contacts.mesh1d_indices[1] == 2
-    assert contacts.mesh1d_indices[2] == 3
+    assert contacts.mesh1d_indices[0] == 0
+    assert contacts.mesh1d_indices[1] == 1
+    assert contacts.mesh1d_indices[2] == 2
+    assert contacts.mesh1d_indices[3] == 3
+    assert contacts.mesh1d_indices[4] == 4
 
-    assert contacts.mesh2d_indices[0] == 6
-    assert contacts.mesh2d_indices[1] == 12
-    assert contacts.mesh2d_indices[2] == 18
+    assert contacts.mesh2d_indices[0] == 0
+    assert contacts.mesh2d_indices[1] == 6
+    assert contacts.mesh2d_indices[2] == 12
+    assert contacts.mesh2d_indices[3] == 18
+    assert contacts.mesh2d_indices[4] == 24
 
 
 def test_contacts_compute_multiple():


### PR DESCRIPTION
because endpoints of mesh1d are now also connected as embedded 1d2d links, since https://github.com/Deltares/MeshKernel/commit/9023ffcf7e59a0e01a8c498054c3038d535e6233