### PR TITLE
GRIDEDIT-2026 Removed 'tj-action/branch-name' yml action. Used github variable.

### DIFF
--- a/.github/workflows/build-and-test-workflow.yml
+++ b/.github/workflows/build-and-test-workflow.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           str="${GITHUB_REF_NAME}"
           if [[ "$str" = "main" ]]; then
-            # MeshKernelPy default barnch is called main, but MeshKernel default branch is called master
+            # MeshKernelPy default branch is called main, but MeshKernel default branch is called master
             str="master"
           elif [[ "$str" =~ ^release/ ]]; then
             # branch name starts with "release/", get the semantic version from MeshKernelPy


### PR DESCRIPTION
tj-action/branch-name is not whitelisted and does not work any more. It has been replaced with a github variable.